### PR TITLE
Practical parameters tuning for cameras

### DIFF
--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
@@ -132,6 +132,11 @@ namespace argos {
       m_fTagSideLength(0.0235f),
       m_strSavePath(str_save_path),
       m_cMetadata("camera") {
+      /* parse camera parameters */
+      GetNodeAttributeOrDefault(t_interface, "camera_brightness", m_unCameraBrightness, m_unCameraBrightness);
+      GetNodeAttributeOrDefault(t_interface, "camera_contrast", m_unCameraContrast, m_unCameraContrast);
+      GetNodeAttributeOrDefault(t_interface, "camera_exposure_auto_mode", m_bCameraExposureAuto, m_bCameraExposureAuto);
+      GetNodeAttributeOrDefault(t_interface, "camera_exposure_absolute_time", m_unCameraExposureAbsoluteTime, m_unCameraExposureAbsoluteTime);
       /* parse calibration data if provided */
       CVector2 cFocalLength;
       CVector2 cPrincipalPoint;
@@ -263,6 +268,30 @@ namespace argos {
       sFormat.fmt.pix.field = V4L2_FIELD_NONE;
       if (::ioctl(m_nCameraHandle, VIDIOC_S_FMT, &sFormat) < 0)
          THROW_ARGOSEXCEPTION("Could not set the camera format");
+      /* set camera control brightness */
+      struct v4l2_control sBrightnessControl;
+      memset(&sBrightnessControl, 0, sizeof (sBrightnessControl));
+      sBrightnessControl.id = V4L2_CID_BRIGHTNESS;
+      sBrightnessControl.value = m_unCameraBrightness;
+      if (::ioctl(m_nCameraHandle, VIDIOC_S_CTRL, &sBrightnessControl) < 0)
+         THROW_ARGOSEXCEPTION("Could not set the camera brightness");
+      /* set camera control contrast */
+      struct v4l2_control sContrastControl;
+      memset(&sContrastControl, 0, sizeof (sContrastControl));
+      sContrastControl.id = V4L2_CID_CONTRAST;
+      sContrastControl.value = m_unCameraContrast;
+      if (::ioctl(m_nCameraHandle, VIDIOC_S_CTRL, &sContrastControl) < 0)
+         THROW_ARGOSEXCEPTION("Could not set the camera contrast");
+      /* set camera control exposure mode */
+      struct v4l2_control sExposureAutoModeControl;
+      memset(&sExposureAutoModeControl, 0, sizeof (sExposureAutoModeControl));
+      sExposureAutoModeControl.id = V4L2_CID_EXPOSURE_AUTO;
+      if (m_bCameraExposureAuto)
+         sExposureAutoModeControl.value = V4L2_EXPOSURE_APERTURE_PRIORITY;
+      else
+         sExposureAutoModeControl.value = V4L2_EXPOSURE_MANUAL;
+      if (::ioctl(m_nCameraHandle, VIDIOC_S_CTRL, &sExposureAutoModeControl) < 0)
+         THROW_ARGOSEXCEPTION("Could not set the camera exposure auto mode");
       /* request camera buffers */
       v4l2_requestbuffers sRequest;
       ::memset(&sRequest, 0, sizeof(sRequest));
@@ -381,6 +410,17 @@ namespace argos {
             sBuffer.index = m_itCurrentBuffer->first;
             if(::ioctl(m_nCameraHandle, VIDIOC_DQBUF, &sBuffer) < 0) {
                THROW_ARGOSEXCEPTION("Could not dequeue buffer");
+            }
+            /* set exposure time after first frame */
+            if ((!m_bCameraExposureAuto) && (!m_bExposureTimeSetFlag)) {
+               m_bExposureTimeSetFlag = true;
+               /* set camera control exposure time*/
+               struct v4l2_control sExposureTimeControl;
+               memset(&sExposureTimeControl, 0, sizeof (sExposureTimeControl));
+               sExposureTimeControl.id = V4L2_CID_EXPOSURE_ABSOLUTE;
+               sExposureTimeControl.value = m_unCameraExposureAbsoluteTime;
+               if (::ioctl(m_nCameraHandle, VIDIOC_S_CTRL, &sExposureTimeControl) < 0)
+                  THROW_ARGOSEXCEPTION("Could not set camera exposure time");
             }
             /* update the timestamp in the control interface */
             Timestamp = sBuffer.timestamp.tv_sec + (10e-6 * sBuffer.timestamp.tv_usec);

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
@@ -15,6 +15,8 @@
 
 #include <apriltag/apriltag.h>
 #include <apriltag/apriltag_pose.h>
+#include <apriltag/tag16h5.h>
+#include <apriltag/tag25h9.h>
 #include <apriltag/tag36h11.h>
 #include <apriltag/common/image_u8.h>
 #include <apriltag/common/zarray.h>
@@ -31,8 +33,6 @@
 #include <chrono>
 #include <algorithm>
 #include <execution>
-
-#define TAG_SIDE_LENGTH 0.0235f
 
 /* hint: the command "v4l2-ctl -d0 --list-formats-ext" lists formats for /dev/video0 */
 /* for testing with a set of images: https://raffaels-blog.de/en/post/fake-webcam/ */
@@ -129,6 +129,7 @@ namespace argos {
                          TConfigurationNode& t_interface,
                          const std::string& str_save_path):
       SInterface(str_label, t_configuration),
+      m_fTagSideLength(0.0235f),
       m_strSavePath(str_save_path),
       m_cMetadata("camera") {
       /* parse calibration data if provided */
@@ -155,7 +156,18 @@ namespace argos {
       cCameraMatrix(0,2) = cPrincipalPoint.GetX();
       cCameraMatrix(1,2) = cPrincipalPoint.GetY();
       /* initialize the apriltag components */
-      m_ptTagFamily = ::tag36h11_create();
+      GetNodeAttributeOrDefault(t_interface, "tag_family", m_strTagFamilyName, m_strTagFamilyName);
+      if (m_strTagFamilyName == "tag16h5")
+         m_ptTagFamily = ::tag16h5_create();
+      else if (m_strTagFamilyName == "tag25h9")
+         m_ptTagFamily = ::tag25h9_create();
+      else if (m_strTagFamilyName == "tag36h11")
+         m_ptTagFamily = ::tag36h11_create();
+      else
+      {
+         LOGERR << "[WARNING] Tag family not specified (using tag36h11 by default)." << std::endl;
+         m_ptTagFamily = ::tag36h11_create();
+      }
       /* create the tag detector */
       m_ptTagDetector = ::apriltag_detector_create();
       /* add the tag family to the tag detector */
@@ -200,11 +212,17 @@ namespace argos {
       m_ptImage =
          ::image_u8_create_alignment(m_arrCaptureResolution[0], m_arrCaptureResolution[1], 96);
       /* update the tag detection info structure */
+      try {
+         GetNodeAttribute(t_interface, "tag_side_length", m_fTagSideLength);
+      }
+      catch(CARGoSException& ex) {
+         LOGERR << "[WARNING] Tag side length not specified (using default length " << m_fTagSideLength << ")." << std::endl;
+      }
       m_tTagDetectionInfo.fx = m_sCalibration.CameraMatrix(0,0);
       m_tTagDetectionInfo.fy = m_sCalibration.CameraMatrix(1,1);
       m_tTagDetectionInfo.cx = m_sCalibration.CameraMatrix(0,2);
       m_tTagDetectionInfo.cy = m_sCalibration.CameraMatrix(1,2);
-      m_tTagDetectionInfo.tagsize = TAG_SIDE_LENGTH;
+      m_tTagDetectionInfo.tagsize = m_fTagSideLength;
       /* set attributes on the camera metadata tag */
       m_cMetadata.SetAttribute("id", str_label);
       m_cMetadata.SetAttribute("processing_offset", strProcessingOffset);

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
@@ -130,7 +130,8 @@ namespace argos {
                          const TConfiguration& t_configuration,
                          TConfigurationNode& t_interface,
                          const std::string& str_save_path):
-      SInterface(str_label, t_configuration),
+      SInterface(str_label),
+      m_tConfiguration(t_configuration),
       m_fTagSideLength(0.0235f),
       m_strSavePath(str_save_path),
       m_cMetadata("camera") {
@@ -145,6 +146,8 @@ namespace argos {
       CVector2 cPrincipalPoint = CVector2(CAMERA_FOCAL_LENGTH_X, CAMERA_FOCAL_LENGTH_Y);
       CVector3 cDistortionK = CVector3(0,0,0);
       CVector2 cDistortionP = CVector2(0,0);
+      CVector3 cCameraPosition = std::get<CVector3>(m_tConfiguration);
+      CQuaternion cCameraOrientation = std::get<CQuaternion>(m_tConfiguration);
       GetNodeAttributeOrDefault(t_interface, "calibration", strCalibrationFilePath, strCalibrationFilePath);
       if(strCalibrationFilePath.empty()) {
          LOGERR << "[WARNING] No calibration data provided for the drone camera system" << std::endl;
@@ -159,6 +162,8 @@ namespace argos {
          GetNodeAttributeOrDefault(tSensorNode, "principal_point", cPrincipalPoint, cPrincipalPoint);
          GetNodeAttributeOrDefault(tSensorNode, "distortion_k", cDistortionK, cDistortionK);
          GetNodeAttributeOrDefault(tSensorNode, "distortion_p", cDistortionP, cDistortionP);
+         GetNodeAttributeOrDefault(tSensorNode, "position", cCameraPosition, cCameraPosition);
+         GetNodeAttributeOrDefault(tSensorNode, "orientation", cCameraOrientation, cCameraOrientation);
       }
       CSquareMatrix<3>& cCameraMatrix = m_sCalibration.CameraMatrix;
       cCameraMatrix.SetIdentityMatrix();
@@ -168,6 +173,8 @@ namespace argos {
       cCameraMatrix(1,2) = cPrincipalPoint.GetY();
       m_sCalibration.DistortionK = cDistortionK;
       m_sCalibration.DistortionP = cDistortionP;
+      std::get<CVector3>(m_tConfiguration) = cCameraPosition;
+      std::get<CQuaternion>(m_tConfiguration) = cCameraOrientation;
       /* initialize the apriltag components */
       GetNodeAttributeOrDefault(t_interface, "tag_family", m_strTagFamilyName, m_strTagFamilyName);
       if (m_strTagFamilyName == "tag16h5")

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.cpp
@@ -553,43 +553,43 @@ namespace argos {
       /* U,V are pixels in the image.
          U+ to the right <--> x,
          V+ down         <--> y  */
-      Real fx = m_sCalibration.CameraMatrix(0,0);
-      Real fy = m_sCalibration.CameraMatrix(1,1);
-      Real cx = m_sCalibration.CameraMatrix(0,2);
-      Real cy = m_sCalibration.CameraMatrix(1,2);
-      Real k1 = m_sCalibration.DistortionK.GetX();
-      Real k2 = m_sCalibration.DistortionK.GetY();
-      Real k3 = m_sCalibration.DistortionK.GetZ();
-      Real p1 = m_sCalibration.DistortionP.GetX();
-      Real p2 = m_sCalibration.DistortionP.GetY();
+      Real fFx = m_sCalibration.CameraMatrix(0,0);
+      Real fFy = m_sCalibration.CameraMatrix(1,1);
+      Real fCx = m_sCalibration.CameraMatrix(0,2);
+      Real fCy = m_sCalibration.CameraMatrix(1,2);
+      Real fK1 = m_sCalibration.DistortionK.GetX();
+      Real fK2 = m_sCalibration.DistortionK.GetY();
+      Real fK3 = m_sCalibration.DistortionK.GetZ();
+      Real fP1 = m_sCalibration.DistortionP.GetX();
+      Real fP2 = m_sCalibration.DistortionP.GetY();
 
-      Real xDistortion = (fU - cx) / fx;
-      Real yDistortion = (fV - cy) / fy;
+      Real fXDistortion = (fU - fCx) / fFx;
+      Real fYDistortion = (fV - fCy) / fFy;
 
-      Real xCorrected, yCorrected;
-      Real x0 = xDistortion;
-      Real y0 = yDistortion;
+      Real fXCorrected, fYCorrected;
+      Real fX0 = fXDistortion;
+      Real fY0 = fYDistortion;
 
       /* start iteration */
-      for (UInt8 i = 0; i < UNDISTORT_ITERATIONS; i++)
+      for (UInt8 unI = 0; unI < UNDISTORT_ITERATIONS; unI++)
       {
-         Real r2 = xDistortion * xDistortion + yDistortion * yDistortion;
-         Real K = 1 / (1. + k1 * r2 + k2 * r2 * r2 + k3 * r2 * r2 * r2);
+         Real fR2 = fXDistortion * fXDistortion + fYDistortion * fYDistortion;
+         Real fK = 1 / (1. + fK1 * fR2 + fK2 * fR2 * fR2 + fK3 * fR2 * fR2 * fR2);
 
-         Real dx = 2. * p1 * xDistortion * yDistortion + p2 * (r2 + 2. * xDistortion * xDistortion);
-         Real dy = p1 * (r2 + 2. * yDistortion * yDistortion) + 2. * p2 * xDistortion * yDistortion;
+         Real fDx = 2. * fP1 * fXDistortion * fYDistortion + fP2 * (fR2 + 2. * fXDistortion * fXDistortion);
+         Real fDy = fP1 * (fR2 + 2. * fYDistortion * fYDistortion) + 2. * fP2 * fXDistortion * fYDistortion;
 
-         xCorrected = (x0 - dx) * K;
-         yCorrected = (y0 - dy) * K;
-         xDistortion = xCorrected;
-         yDistortion = yCorrected;
+         fXCorrected = (fX0 - fDx) * fK;
+         fYCorrected = (fY0 - fDy) * fK;
+         fXDistortion = fXCorrected;
+         fYDistortion = fYCorrected;
       }
 
-      xCorrected = xCorrected * fx + cx;
-      yCorrected = yCorrected * fy + cy;
+      fXCorrected = fXCorrected * fFx + fCx;
+      fYCorrected = fYCorrected * fFy + fCy;
 
-      fU = xCorrected;
-      fV = yCorrected;
+      fU = fXCorrected;
+      fV = fYCorrected;
    }
 
    /****************************************/

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
@@ -88,6 +88,8 @@ namespace argos {
          std::array<UInt32, 2> m_arrProcessingResolution;
          std::array<UInt32, 2> m_arrProcessingOffset;
          /* tag detector data */
+         std::string m_strTagFamilyName;
+         Real m_fTagSideLength;
          ::image_u8_t* m_ptImage;
          ::apriltag_family* m_ptTagFamily;
          ::apriltag_detector* m_ptTagDetector;

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
@@ -76,7 +76,13 @@ namespace argos {
             return m_cMetadata;
          }
 
+         const TConfiguration& GetSensorConfiguration() const {
+            return m_tConfiguration;
+         };
+
       private:
+         /* camera position and orientation */
+         TConfiguration m_tConfiguration;
          /* calibration data */
          struct SCalibration {
             CVector3 PositionError;

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
@@ -87,6 +87,12 @@ namespace argos {
          std::array<UInt32, 2> m_arrCaptureResolution;
          std::array<UInt32, 2> m_arrProcessingResolution;
          std::array<UInt32, 2> m_arrProcessingOffset;
+         /* camera parameters */
+         UInt8 m_unCameraBrightness = 8;
+         UInt8 m_unCameraContrast = 8;
+         bool m_bCameraExposureAuto = true;
+         UInt16 m_unCameraExposureAbsoluteTime = 1250;
+         bool m_bExposureTimeSetFlag = false;
          /* tag detector data */
          std::string m_strTagFamilyName;
          Real m_fTagSideLength;

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
@@ -82,7 +82,10 @@ namespace argos {
             CVector3 PositionError;
             CQuaternion OrientationError;
             CSquareMatrix<3> CameraMatrix;
+            CVector3 DistortionK;
+            CVector2 DistortionP;
          } m_sCalibration;
+         void UndistortPixel(double& fU, double& fV);
          /* sensor configuration */
          std::array<UInt32, 2> m_arrCaptureResolution;
          std::array<UInt32, 2> m_arrProcessingResolution;

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
@@ -134,6 +134,10 @@ namespace argos {
       /* path to save camera sensor data */
       std::string m_strSensorDataPath;
 
+   private:
+      static const UInt8 UNDISTORT_ITERATIONS;
+      static const Real DEFAULT_TAG_SIDE_LENGTH;
+
       /****************************************/
       /****************************************/
 

--- a/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
+++ b/src/plugins/robots/drone/hardware/drone_cameras_system_default_sensor.h
@@ -76,13 +76,11 @@ namespace argos {
             return m_cMetadata;
          }
 
-         const TConfiguration& GetSensorConfiguration() const {
+         const TConfiguration& GetConfiguration() const {
             return m_tConfiguration;
          };
 
       private:
-         /* camera position and orientation */
-         TConfiguration m_tConfiguration;
          /* calibration data */
          struct SCalibration {
             CVector3 PositionError;
@@ -102,6 +100,8 @@ namespace argos {
          bool m_bCameraExposureAuto = true;
          UInt16 m_unCameraExposureAbsoluteTime = 1250;
          bool m_bExposureTimeSetFlag = false;
+         /* camera position and orientation */
+         TConfiguration m_tConfiguration;
          /* tag detector data */
          std::string m_strTagFamilyName;
          Real m_fTagSideLength;


### PR DESCRIPTION
We add interface in .argos file to :
1. specify tag family and tag size
2. specify camera sensor parameters such as brightness and exposure time
3. specify camera intrinsic parameters, and undistort tag corners according to distortion parameters to detect the correct position & orientation
4. specify camera extrinsic parameters.